### PR TITLE
Partial pattern matches in do-notation break on 8.6 w/ no MonadFail constraint

### DIFF
--- a/src/Graphics/UI/GIGtkStrut.hs
+++ b/src/Graphics/UI/GIGtkStrut.hs
@@ -2,6 +2,7 @@ module Graphics.UI.GIGtkStrut where
 
 import           Control.Monad
 import           Control.Monad.IO.Class
+import           Control.Monad.Fail (MonadFail)
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Maybe
 import           Data.Int
@@ -37,13 +38,13 @@ defaultStrutConfig = StrutConfig
   , strutDisplayName = Nothing
   }
 
-buildStrutWindow :: MonadIO m => StrutConfig -> m Gtk.Window
+buildStrutWindow :: (MonadFail m, MonadIO m) => StrutConfig -> m Gtk.Window
 buildStrutWindow config = do
   window <- Gtk.windowNew Gtk.WindowTypeToplevel
   setupStrutWindow config window
   return window
 
-setupStrutWindow :: MonadIO m => StrutConfig -> Gtk.Window -> m ()
+setupStrutWindow :: (MonadFail m, MonadIO m) => StrutConfig -> Gtk.Window -> m ()
 setupStrutWindow StrutConfig
               { strutWidth = widthSize
               , strutHeight = heightSize


### PR DESCRIPTION
Currently the build fails on GHC 8.6 with:
```
src/Graphics/UI/GIGtkStrut.hs:58:3: error:
    • Could not deduce (Control.Monad.Fail.MonadFail m)
        arising from a do statement
        with the failable pattern ‘Just monitor’
      from the context: MonadIO m
        bound by the type signature for:
                   setupStrutWindow :: forall (m :: * -> *).
                                       MonadIO m =>
                                       StrutConfig -> Gtk.Window -> m ()
        at src/Graphics/UI/GIGtkStrut.hs:46:1-66
      Possible fix:
        add (Control.Monad.Fail.MonadFail m) to the context of
          the type signature for:
            setupStrutWindow :: forall (m :: * -> *).
                                MonadIO m =>
                                StrutConfig -> Gtk.Window -> m ()
    • In a stmt of a 'do' block:
        Just monitor <- maybe
                          (Gdk.displayGetPrimaryMonitor display)
                          (Gdk.displayGetMonitor display)
                          monitorNumber
      In the expression:
        do Just display <- maybe
                             Gdk.displayGetDefault Gdk.displayOpen displayName
           Just monitor <- maybe
                             (Gdk.displayGetPrimaryMonitor display)
                             (Gdk.displayGetMonitor display)
                             monitorNumber
           screen <- Gdk.displayGetDefaultScreen display
           monitorCount <- Gdk.displayGetNMonitors display
           ....
      In an equation for ‘setupStrutWindow’:
          setupStrutWindow
            StrutConfig {strutWidth = widthSize, strutHeight = heightSize,
                         strutXPadding = xpadding, strutYPadding = ypadding,
                         strutMonitor = monitorNumber, strutPosition = position,
                         strutAlignment = alignment, strutDisplayName = displayName}
            window
            = do Just display <- maybe
                                   Gdk.displayGetDefault Gdk.displayOpen displayName
                 Just monitor <- maybe
                                   (Gdk.displayGetPrimaryMonitor display)
                                   (Gdk.displayGetMonitor display)
                                   monitorNumber
                 screen <- Gdk.displayGetDefaultScreen display
                 ....
   |
58 |   Just monitor <- maybe (Gdk.displayGetPrimaryMonitor display)
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```

Adding a MonadFail constraint seems to fix it.

See the MonadFailDesugaring section of
https://ghc.haskell.org/trac/ghc/wiki/Migration/8.6.